### PR TITLE
Add simple docs for components and pages

### DIFF
--- a/src/components/SignedInTabs.tsx
+++ b/src/components/SignedInTabs.tsx
@@ -13,6 +13,10 @@ import StartWorkout from '../pages/StartWorkout';
 import CreateWorkout from '../pages/CreateWorkout';
 import History from '../pages/History';
 
+/**
+ * This component is the main tab bar for the app. It contains the routes for
+ * the main pages of the app when the user is signed in.
+ */
 const SignedInTabs: React.FC = () => (
   <IonTabs>
     <IonRouterOutlet>

--- a/src/components/SignedOutTabs.tsx
+++ b/src/components/SignedOutTabs.tsx
@@ -11,6 +11,10 @@ import { ellipse, triangle } from 'ionicons/icons';
 import SignUp from '../pages/SignUp';
 import Login from '../pages/Login';
 
+/**
+ * This component is the main tab bar for the app. It contains the routes for
+ * the main pages of the app when the user is signed out.
+ */
 const SignedOutTabs: React.FC = () => (
   <IonTabs>
     <IonRouterOutlet>

--- a/src/pages/CreateWorkout.tsx
+++ b/src/pages/CreateWorkout.tsx
@@ -1,5 +1,8 @@
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 
+/**
+ * This component is the page responsible for creating a new workout.
+ */
 const CreateWorkout: React.FC = () => {
   return (
     <IonPage>

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -1,5 +1,8 @@
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 
+/**
+ * This component is the page responsible for displaying the workout history.
+ */
 const WorkoutHistory: React.FC = () => {
   return (
     <IonPage>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,9 @@
 import { IonContent, IonHeader, IonList, IonItem, IonPage, IonTitle, IonToolbar, IonLabel, IonInput, IonButtons, IonButton, IonIcon } from '@ionic/react';
 import { useRef } from 'react';
 
+/**
+ * This component is the page responsible for logging in.
+ */
 const Login: React.FC = () => {
   let usernameInputRef = useRef<HTMLIonInputElement>(null);
   let passwordInputRef = useRef<HTMLIonInputElement>(null);

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,6 +1,9 @@
 import { IonButton, IonButtons, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonList, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 import { useRef } from 'react';
 
+/**
+ * This component is the page responsible for signing up.
+ */
 const SignUp: React.FC = () => {
   let usernameInputRef = useRef<HTMLIonInputElement>(null);
   let passwordInputRef = useRef<HTMLIonInputElement>(null);

--- a/src/pages/StartWorkout.tsx
+++ b/src/pages/StartWorkout.tsx
@@ -1,5 +1,8 @@
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 
+/**
+ * This component is the page responsible for starting a workout.
+ */
 const StartWorkout: React.FC = () => {
   return (
     <IonPage>

--- a/src/pages/Workouts.tsx
+++ b/src/pages/Workouts.tsx
@@ -1,5 +1,9 @@
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 
+/**
+ * This component is the page responsible for displaying the user-generated
+ * workouts.
+ */
 const Workouts: React.FC = () => {
   return (
     <IonPage>


### PR DESCRIPTION
- Add doc blocks to components and pages to make it easier to understand what one is responsible for. Started off simple due to not wanting to pigeon-hole implementations.